### PR TITLE
fix Read DMAR IQA REG DW

### DIFF
--- a/hw/i386/intel_iommu.c
+++ b/hw/i386/intel_iommu.c
@@ -4799,7 +4799,8 @@ static uint64_t vtd_mem_read(void *opaque, hwaddr addr, unsigned size)
 
     /* Invalidation Queue Address Register, 64-bit */
     case DMAR_IQA_REG:
-        val = s->iq | (vtd_get_quad(s, DMAR_IQA_REG) & VTD_IQA_QS);
+        val = s->iq | (vtd_get_quad(s, DMAR_IQA_REG) & VTD_IQA_QS
+                | VTD_IQA_DW_MASK );
         if (size == 4) {
             val = val & ((1ULL << 32) - 1);
         }


### PR DESCRIPTION
When dmar_readq or devmem2 read the DW of IQA always 0UL because "& VTD_IQA_QS". So, try to fix it.

case:
after vtd_mem_write
IQA val: 0x100206801

after vtd_mem_read
IQA val: 0x100206001